### PR TITLE
Add ability to specify custom template with key-value parameters

### DIFF
--- a/up.go
+++ b/up.go
@@ -6,12 +6,14 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"text/template"
 )
 
 type options struct {
 	allowMissing bool
 	applyUpByOne bool
 	noVersioning bool
+	template     *template.Template
 }
 
 type OptionsFunc func(o *options)
@@ -22,6 +24,10 @@ func WithAllowMissing() OptionsFunc {
 
 func WithNoVersioning() OptionsFunc {
 	return func(o *options) { o.noVersioning = true }
+}
+
+func WithTemplate(t *template.Template) OptionsFunc {
+	return func(o *options) { o.template = t }
 }
 
 func withApplyUpByOne() OptionsFunc {


### PR DESCRIPTION
Allow to specify template and pass key-value parameters as arguments of template
```
tmpl := template.Must(template.New("goose.go-migration.custom").Parse(`
{{index .Values "foo"}} {{index .Values "bar"}}
Name {{.CamelName}}
Version {{.Version}}
`))

args := []string { "MyMigration", "go", "foo=hello", "bar=world" }

if err = goose.RunWithOptions("create", db, dir, args, goose.WithTemplate(tmpl)); err != nil {
  .....
}
```